### PR TITLE
Support all multi-line strings

### DIFF
--- a/grammars/hocon.cson
+++ b/grammars/hocon.cson
@@ -22,6 +22,9 @@ patterns: [
     include: "#constant"
   }
   {
+    include: "#mstring"
+  }
+  {
     include: "#string"
   }
   {
@@ -96,6 +99,11 @@ repository:
     comment: "handles integer and decimal numbers"
     match: "(\\b\\-?\\d+(\\.\\d+)?([eE]\\d+)?\\b)"
     name: "constant.numeric.zzz.simple.numbers.hocon"
+  mstring:
+    comment: "handles multi-line strings"
+    begin: "\"\"\""
+    end: "\"\"\""
+    name: "string.quoted.triple.hocon"
   string:
     begin: "\""
     end: "\""


### PR DESCRIPTION
The current grammar can usually handle multi-line strings via the `string.quoted.double.hocon` entry, but if there are double quotes within the multi-line string then it all goes a bit haywire. The HOCON spec[1] allows for any characters between the two triple quotes, so this change is to meet that criteria. I'm not sure how to formally test it but it has resolved those edge cases in my own HOCON docs.

[1] https://github.com/lightbend/config/blob/master/HOCON.md#multi-line-strings