### PR TITLE
Support key-value-pairs separated by a colon

### DIFF
--- a/grammars/hocon.cson
+++ b/grammars/hocon.cson
@@ -40,7 +40,7 @@ patterns: [
     include: "#ustring"
   }
   {
-    match: '(?:^[ \t]*([\\w-]+)\\s*?({|=))'
+    match: '(?:^[ \t]*([\\w-]+)\\s*?({|=|:))'
     captures:
       '1':
         'name': 'entity.name.tag.hocon'


### PR DESCRIPTION
This is a fix for issue #5. Keys can be separated from values by a colon, as per: https://github.com/lightbend/config/blob/master/HOCON.md#key-value-separator