### PR TITLE
Fix invalid unquoted string keys rule

### DIFF
--- a/grammars/hocon.cson
+++ b/grammars/hocon.cson
@@ -1,5 +1,6 @@
 fileTypes: [
-  "conf"
+  "conf",
+  "hocon"
 ]
 name: "HOCON"
 patterns: [
@@ -40,23 +41,23 @@ patterns: [
     include: "#ustring"
   }
   {
-    match: '(?:^[ \t]*([\\w-]+)\\s*?({|=|:))'
+    match: '(?:[ \t]*([\\w-]+)\\s*?({|=|:))'
     captures:
       '1':
         'name': 'entity.name.tag.hocon'
       '2':
         'name': 'punctuation.separator.key-value.hocon'
-    end: '(\\=|{)'
   }
 ]
 repository:
+   # https://github.com/lightbend/config/blob/main/HOCON.md#size-in-bytes-format
   "bytesize-long":
     comment: "handles byte-based units (long version)"
     match: "\\b\\d+((kilo|mega|giga|tera|peta|exa|zetta|yotta|kibi|mebi|gibi|tebi|pebi|exbi|zebo|yobi)?byte[s]?)\\b"
     name: "constant.numeric.byte.long.hocon"
   "bytesize-short":
     comment: "handles byte-based units (short version)"
-    match: "\\b\\d+(([kMGTPEZY]B)|([KMGTPEZY]i[B]?)|([kmgtpezybB]))\\b"
+    match: "\\b\\d+(([kMGTPEZY]B)|([KMGTPEZY]B?)|([KMGTPEZY]iB?)|([kmgtpezybB]))\\b"
     name: "constant.numeric.byte.short.hocon"
   comments:
     patterns: [
@@ -120,7 +121,7 @@ repository:
     ]
   ustring:
     comment: "unquoted strings"
-    match: "([^=\\{\\}\\[\\]\\s][^0-9=\\{\\}\\[\\]][^=\\{\\}\\[\\]\\s]*)$"
+    match: "([^:=\\{\\}\\[\\]\\s,][^0-9:=\\{\\}\\[\\],][^=:\\{\\}\\[\\]\\s,]*)"
     captures:
       '1':
         name: 'entity.name.tag.hocon'


### PR DESCRIPTION
Hi!  (following a discussion in https://github.com/github/linguist/discussions/6253) This PR fixes the invalid unquoted string rule (see https://macromates.com/manual/en/language_grammars Rule Keys section):
```cson
    match: '(?:^[ \t]*([\\w-]+)\\s*?({|=|:))'
    captures:
      '1':
        'name': 'entity.name.tag.hocon'
      '2':
        'name': 'punctuation.separator.key-value.hocon'
    end: '(\\=|{)'
```
Which is invalid since `match` and `begin`/`end` are mutually exclusive.  I've removed the `end` - I think this is fine, I can't find a circumstance this breaks something.

I've also fixed extra stuff I found whilst debugging this, I'll comment the PR with the specifics.  I've mainly tested the grammar using files from: https://github.com/emqx/hocon/tree/master/sample-configs.

Comments welcome, thanks :slightly_smiling_face: 